### PR TITLE
fix listening events

### DIFF
--- a/lib/Marathon/Events.pm
+++ b/lib/Marathon/Events.pm
@@ -25,7 +25,7 @@ sub start {
     my $addr_port = $addr;
     if ($addr !~ /:/) {
         if ($marathon_url =~ /^https/) {
-            $addr_port .= '443';
+            $addr_port .= ':443';
         }
         else { # =~ /^http/
             $addr_port .= ':80';

--- a/lib/Marathon/Events.pm
+++ b/lib/Marathon/Events.pm
@@ -19,12 +19,20 @@ sub callbacks {
 }
 
 sub start {
-    my $self = shift;
-    my $cv = AnyEvent->condvar;
-    $self->{parent}->{_url} =~ m,https?\://([^/]+),;
-    my $addr = $1;
+    my ($self, $cv) = @_;
 
-    my $io = io($addr);
+    my ($addr) = $self->{parent}{_url} =~ m{ https?://([^/]+) }x;
+    my $addr_port = $addr;
+    if ($addr !~ /:/) {
+        if ($marathon_url =~ /^https/) {
+            $addr_port .= '443';
+        }
+        else { # =~ /^http/
+            $addr_port .= ':80';
+        }
+    }
+
+    my $io = io($addr_port);
     $io->print("GET /v2/events HTTP/1.1\nAccept: text/event-stream\nHost: $addr\n\n");
     while (<$io>) {
         last if /^\s*$/;
@@ -35,8 +43,7 @@ sub start {
             $_->($text);
         }
     };
-    print STDERR "yield\n";
-    return $io;
+    return $watcher;
 }
 
 1;


### PR DESCRIPTION
Hi, thanks for Marathon module! I needed this changes to be able to work with event API. Please note it changes the interface, condvar is passed to start method and the IO watcher is returned. Thanks to that, I can use the method from outside. I was unable to do it before as the `$watcher` variable lost scope and was destroyed which lead to not receiving events anymore.

Now it can be used like this:
```perl
my $cv = AnyEvent->condvar;
my $events = $marathon->events();
$events->register( sub { print @_ });
my $watcher = $events->start($cv);
$cv->recv();
```

Could you please merge this change? Otherwise I need to use my forked version.

Thanks, Miroslav